### PR TITLE
Fix readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ node_modules
 
 # deployment
 *.retry
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ with your favourite package manager.
 
 Next, install the global build tools if not present yet:
 
-    npm install grunt-cli bower -g
+    npm install grunt-cli -g
 
 And install the project dev dependencies:
 
     npm install
-    bower install
 
 To watch the sass files and recompile sass to css on the fly, run:
 


### PR DESCRIPTION
Remove `bower` from README, doesn't seem like it's used anywhere. Plus it's almost 2020 after all :3